### PR TITLE
Cz janza update long term leave users in security group

### DIFF
--- a/runbooks/Update-LongTermLeaveUsers.ps1
+++ b/runbooks/Update-LongTermLeaveUsers.ps1
@@ -187,10 +187,10 @@ $attachments = @(
 )
 
 Send-EmailReport -SendGridApiKey $sendGridApiKey `
-    -SendGridApiEndpoint $SendGridApiEndpoint `
-    -SenderEmailAddress $SendGridSenderEmailAddress `
-    -RecipientEmailAddresses $recipientArray `
-    -Subject "Group Membership Update Report: $GroupName" `
-    -Content $emailContent `
-    -Attachments $attachments
+                 -SendGridApiEndpoint $SendGridApiEndpoint `
+                 -SenderEmailAddress $SendGridSenderEmailAddress `
+                 -RecipientEmailAddresses $recipientArray `
+                 -Subject "Group Membership Update Report: $GroupName" `
+                 -Content $emailContent `
+                 -Attachments $attachments
 


### PR DESCRIPTION
new runbook, the purpose is to take the export from workday stored in new sftp and update security group membership weekly with these users.